### PR TITLE
':' removal for win-paths fix

### DIFF
--- a/mpmInstallDir.m
+++ b/mpmInstallDir.m
@@ -4,5 +4,9 @@ function MPM_INSTALL_DIR = mpmInstallDir()
     if ~exist('MPM_INSTALL_DIR', 'var')
         error('MPM_INSTALL_DIR was not defined in config.m');
     end
-    MPM_INSTALL_DIR = strrep(MPM_INSTALL_DIR, ':', '');
+    if ispc
+        % do nothing
+    else
+        MPM_INSTALL_DIR = strrep(MPM_INSTALL_DIR, ':', '');
+    end
 end


### PR DESCRIPTION
Hi, 

the mpmInstallDir.m function behaves incorrectly when dealing with win-paths, where all paths inculde ':' sign by default, e.g. 'C:\foo\bar'. Thus mpmpaths fails to update paths. This fixes the issue

Thanks,
Mike