### PR TITLE
Add basic environment feature

### DIFF
--- a/mpm_config.m
+++ b/mpm_config.m
@@ -1,15 +1,14 @@
 function opts = mpm_config()
 
     opts = struct();
-    
-    % set default directory to install packages
-    curdir = fileparts(mfilename('fullpath'));
-    opts.DEFAULT_INSTALL_DIR = fullfile(curdir, 'mpm-packages');
-    
+
+    % override environment base directory
+    opts.DEFAULT_ENVIRONMENT_BASE = '';
+
     % search github before searching Matlab File Exchange?
     opts.DEFAULT_CHECK_GITHUB_FIRST = false;
-    
+
     % update all paths on each install?
-    opts.update_mpm_paths = false;    
+    opts.update_mpm_paths = false;
 
 end


### PR DESCRIPTION
So instead of setting install paths with -d, these minimal changes allow
for an environment name to be specified. The base install directory is
then build from a os specific, overridable environment base (e.g.
`~/.mpm`) and the environment name.

Examples:

```
>> mpm install eeglab -e default -u https://github.com/jukka/eeglab.git
Collecting 'eeglab'...
   Downloading https://github.com/jukka/eeglab/zipball/master...
   Adding package to metadata in /home/mk/.mpm/default/mpm.mat
Updating paths...
   Adding to path: /home/mk/.mpm/default/eeglab
   Using environment default
   Added paths for 1 package(s).
```

```
>> mpm init -e testing
   Using environment testing
   Added paths for 0 package(s).
>> mpm init
   Using environment default
   Adding to path: /home/mk/.mpm/default/tikz2matlab/src
   Adding to path: /home/mk/.mpm/default/eeglab
   Added paths for 2 package(s).
```

What do you think?