### PR TITLE
Bugfix - surround paths with double quotes.

### DIFF
--- a/mpm.m
+++ b/mpm.m
@@ -534,7 +534,7 @@ end
 function isOk = checkoutFromUrl(pkg)
 % git checkout from url to installdir
     isOk = true;
-    flag = system(['git clone ', pkg.url, ' ', pkg.installdir]);
+    flag = system(['git clone ', pkg.url, ' "', pkg.installdir, '"']);
     
     if (flag ~= 0)
         isOk = false;


### PR DESCRIPTION
Fixes the call to git clone so target location paths with spaces work.