### PR TITLE
Fixes #69 Support for fetching branches, tags and commit hashes and #68 Tag flag is ignored when using url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry.mathworks.com/matlab:R2018a
+
+USER root
+
+RUN apt-get update && \
+    apt-get install -y unzip vim git
+
+USER matlab
+
+WORKDIR /matlab

--- a/mpm.m
+++ b/mpm.m
@@ -539,7 +539,7 @@ function isOk = checkoutFromUrl(pkg)
     else
         branch = 'master'
     end
-    flag = system(['git clone --quiet -c advice.detachedHead=false --depth 1 --branch ', branch, ' ', pkg.url, ' "', pkg.installdir, '"']);
+    flag = system(['git clone -c advice.detachedHead=false --depth 1 --branch ', branch, ' ', pkg.url, ' "', pkg.installdir, '"']);
     
     if (flag ~= 0)
         isOk = false;

--- a/mpm.m
+++ b/mpm.m
@@ -534,7 +534,12 @@ end
 function isOk = checkoutFromUrl(pkg)
 % git checkout from url to installdir
     isOk = true;
-    flag = system(['git clone ', pkg.url, ' "', pkg.installdir, '"']);
+    if ~isempty(pkg.release_tag)
+        branch = pkg.release_tag
+    else
+        branch = 'master'
+    end
+    flag = system(['git clone --quiet -c advice.detachedHead=false --depth 1 --branch ', branch, ' ', pkg.url, ' "', pkg.installdir, '"']);
     
     if (flag ~= 0)
         isOk = false;

--- a/test/test_install.m
+++ b/test/test_install.m
@@ -1,8 +1,27 @@
 clear
+mpm_dir = fullfile(pwd, '..');
+addpath(mpm_dir)
 
-addpath(fullfile(fileparts(mfilename), '..'))
+% test install zip - default master branch
+mpm install matlab2tikz -u https://github.com/matlab2tikz/matlab2tikz.git --force
+matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz')
+assert(exist(fullfile(matlab2tikz_dir, 'src/matlab2tikz.m'), 'file')==2)
+assert(~isempty(which('matlab2tikz')))
 
-%% test install
+% test install zip - specific tag
+mpm install matlab2tikz -t 0.4.7 -u https://github.com/matlab2tikz/matlab2tikz.git --force
+assert(exist(fullfile(matlab2tikz_dir, 'version-0.4.7'), 'file')==2)
+assert(~isempty(which('matlab2tikz')))
+
+% test install zip - specific branch
+mpm install matlab2tikz -t develop -u https://github.com/matlab2tikz/matlab2tikz.git --force
+assert(exist(fullfile(matlab2tikz_dir, 'test/suites/ACID.Octave.4.2.0.md5'), 'file')==2)
+assert(~isempty(which('matlab2tikz')))
+
+% test install zip - specific commit hash
+mpm install matlab2tikz -t ca56d9f -u https://github.com/matlab2tikz/matlab2tikz.git --force
+assert(exist(fullfile(matlab2tikz_dir, 'version-0.3.3'), 'file')==2)
+assert(~isempty(which('matlab2tikz')))
 
 % Does not work
 % mpm install export_fig -u http://www.mathworks.com/matlabcentral/fileexchange/23629-export-fig
@@ -13,29 +32,18 @@ addpath(fullfile(fileparts(mfilename), '..'))
 % mpm install matlab2tikz --force
 
 mpm install colorbrewer --force
-
-
-install_dir = fullfile(fileparts(mfilename('fullpath')), '..', ...
-    'mpm-packages', 'colorbrewer');
+colorbrewer_dir = fullfile(mpm_dir, 'mpm-packages', 'colorbrewer');
 
 % test that the directory has been created
 % that the file is there and has been added to the path
-assert(exist(install_dir, 'dir')==7); 
-
-cd(install_dir)
-assert(exist(fullfile(pwd, 'brewermap.m'), 'file')==2)
-
-assert(isequal(which('brewermap'), fullfile(pwd, 'brewermap.m')))
-
+assert(exist(colorbrewer_dir, 'dir')==7)
+assert(exist(fullfile(colorbrewer_dir, 'brewermap.m'), 'file')==2)
+assert(~isempty(which('brewermap')))
 
 %% test uninstall
-
 mpm uninstall colorbrewer --force
 
 % test that everything is removed
-assert(exist(install_dir, 'dir')==0); 
-assert(exist(fullfile(pwd, 'brewermap.m'), 'file')==0)
-assert(isequal(which('brewermap'), ''))
-
-
-
+assert(exist(colorbrewer_dir, 'dir')==0)
+assert(exist(fullfile(colorbrewer_dir, 'brewermap.m'), 'file')==0)
+assert(isempty(which('brewermap')))


### PR DESCRIPTION
Git clone now does a shallow clone to a specific branch (which can be a tag, commit hash or branch name) with default branch of 'master'

