### PR TITLE
Install using api not working and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ __Search without installing:__
 __Install from a url:__
 
 ```
->> mpm install export_fig -u http://www.mathworks.com/matlabcentral/fileexchange/23629-export-fig
+>> mpm install covidx -u https://www.mathworks.com/matlabcentral/fileexchange/76213-covidx
 ```
 OR:
 
@@ -118,6 +118,8 @@ Using collection "test"
 Specifying a requirements file lets you install or search for multiple packages at once. See 'requirements-example.txt' for an example. Make sure to provide an absolute path to the file!
 
 By default, mpm tries to find the best folder in the package to add to your Matlab path. To install a package without modifying any paths, set `--nopaths`. Or to add _all_ subfolders in a package to the path, set `--allpaths`.
+
+To automatically confirm installation without being prompted, set `--approve`. Note that this is only available when installing packages from file.
 
 ## What it does
 

--- a/mpm.m
+++ b/mpm.m
@@ -407,6 +407,7 @@ function url = findUrlOnGithub(pkg)
     if isempty(query)
         query = pkg.name;
     end
+
     % query github for matlab repositories
     % https://developer.github.com/v3/search/#search-repositories
     % ' ' will be replaced by '+', which seems necessary
@@ -417,6 +418,7 @@ function url = findUrlOnGithub(pkg)
     if isempty(html) || ~isfield(html, 'items') || isempty(html.items)
         return;
     end
+
     % take first repo
     item = html.items(1);
     

--- a/mpm.m
+++ b/mpm.m
@@ -407,7 +407,6 @@ function url = findUrlOnGithub(pkg)
     if isempty(query)
         query = pkg.name;
     end
-    
     % query github for matlab repositories
     % https://developer.github.com/v3/search/#search-repositories
     % ' ' will be replaced by '+', which seems necessary
@@ -418,22 +417,12 @@ function url = findUrlOnGithub(pkg)
     if isempty(html) || ~isfield(html, 'items') || isempty(html.items)
         return;
     end
-
     % take first repo
     item = html.items(1);
     
     if ~isempty(pkg.release_tag)
         % if release tag set, return the release matching this tag
-        res = webread(item.tags_url);
-        if isempty(res) || ~isfield(res, 'zipball_url')
-            return;
-        end
-        ix = strcmpi({res.name}, pkg.release_tag);
-        if sum(ix) == 0
-            return;
-        end
-        ind = find(ix, 1, 'first');
-        url = res(ind).zipball_url;
+        url = [item.url '/zipball/' pkg.release_tag];
     else
         rel_url = [item.url '/releases/latest'];
         try

--- a/mpm.m
+++ b/mpm.m
@@ -460,23 +460,16 @@ function [pkg, isOk] = installPackage(pkg, opts)
         rmdir(pkg.installdir, 's');
     end
     
-    if ~opts.local_install && ~isempty(strfind(pkg.url, '.git')) && ...
-            isempty(strfind(pkg.url, 'github.com'))
-        % install with git clone because not on github
-        isOk = checkoutFromUrl(pkg);
-        if ~isOk
-            warning('Error using git clone');
-        end
-    elseif ~opts.local_install
+    if ~opts.local_install
         % download zip
         pkg.url = handleCustomUrl(pkg.url, pkg.release_tag);
         [isOk, pkg] = unzipFromUrl(pkg);
-        if ~isOk && ~isempty(strfind(pkg.url, 'github.com')) && ...
-            isempty(strfind(pkg.url, '.git'))
-            warning(['If you were trying to install a github repo, ', ...
-                'try adding ".git" to the end.']);
-        elseif ~isOk
-            warning('Error downloading zip.');
+        if ~isOk
+            % git clone
+            isOk = checkoutFromUrl(pkg);
+            if ~isOk
+                warning('Error downloading ', pkg.url);
+            end
         end
     else % local install (using pre-existing local directory)
         % make sure path exists

--- a/requirements-example.txt
+++ b/requirements-example.txt
@@ -1,3 +1,3 @@
-export_fig -u http://www.mathworks.com/matlabcentral/fileexchange/23629-export-fig
+export_fig -u https://github.com/altmany/export_fig.git
 matlab2tikz -t 1.0.0
 colorbrewer

--- a/test/test_install.m
+++ b/test/test_install.m
@@ -1,49 +1,107 @@
 clear
+warning('off','backtrace')
+
 mpm_dir = fullfile(pwd, '..');
 addpath(mpm_dir)
 
-% test install zip - default master branch
-mpm install matlab2tikz -u https://github.com/matlab2tikz/matlab2tikz.git --force
-matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz')
-assert(exist(fullfile(matlab2tikz_dir, 'src/matlab2tikz.m'), 'file')==2)
-assert(~isempty(which('matlab2tikz')))
 
-% test install zip - specific tag
-mpm install matlab2tikz -t 0.4.7 -u https://github.com/matlab2tikz/matlab2tikz.git --force
+%
+% Test Install using GitHub api (no url)
+%
+
+%% Test install of latest release
+mpm install export_fig --force
+export_fig_dir = fullfile(mpm_dir, 'mpm-packages', 'export_fig');
+assert(exist(fullfile(export_fig_dir, 'export_fig.m'), 'file')==2)
+assert(~isempty(which('export_fig')))
+
+%% Test install of specific tag
+mpm install matlab2tikz -t 0.4.7 --force
+matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
 assert(exist(fullfile(matlab2tikz_dir, 'version-0.4.7'), 'file')==2)
 assert(~isempty(which('matlab2tikz')))
 
-% test install zip - specific branch
-mpm install matlab2tikz -t develop -u https://github.com/matlab2tikz/matlab2tikz.git --force
+%% Test install of specific branch
+mpm install matlab2tikz -t develop --force
+matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
 assert(exist(fullfile(matlab2tikz_dir, 'test/suites/ACID.Octave.4.2.0.md5'), 'file')==2)
 assert(~isempty(which('matlab2tikz')))
 
-% test install zip - specific commit hash
-mpm install matlab2tikz -t ca56d9f -u https://github.com/matlab2tikz/matlab2tikz.git --force
+%% Test install of specific commit hash
+mpm install matlab2tikz -t ca56d9f --force
+matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
 assert(exist(fullfile(matlab2tikz_dir, 'version-0.3.3'), 'file')==2)
 assert(~isempty(which('matlab2tikz')))
 
-% Does not work
-% mpm install export_fig -u http://www.mathworks.com/matlabcentral/fileexchange/23629-export-fig
-% mpm install matlab2tikz -t 1.0.0
 
-% Works
-% mpm install export_fig -u https://github.com/altmany/export_fig.git --force
-% mpm install matlab2tikz --force
+%
+% Test Install using URL with .git file extension
+%
 
+%% Test install of default branch (master)
+mpm install matlab2tikz -u https://github.com/matlab2tikz/matlab2tikz.git --force
+matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
+assert(exist(fullfile(matlab2tikz_dir, 'src/matlab2tikz.m'), 'file')==2)
+assert(~isempty(which('matlab2tikz')))
+
+%% Test install of specific tag
+mpm install matlab2tikz -t 0.4.7 -u https://github.com/matlab2tikz/matlab2tikz.git --force
+matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
+assert(exist(fullfile(matlab2tikz_dir, 'version-0.4.7'), 'file')==2)
+assert(~isempty(which('matlab2tikz')))
+
+%% Test install of specific branch
+mpm install matlab2tikz -t develop -u https://github.com/matlab2tikz/matlab2tikz.git --force
+matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
+assert(exist(fullfile(matlab2tikz_dir, 'test/suites/ACID.Octave.4.2.0.md5'), 'file')==2)
+assert(~isempty(which('matlab2tikz')))
+
+%% Test install of specific commit hash
+mpm install matlab2tikz -t ca56d9f -u https://github.com/matlab2tikz/matlab2tikz.git --force
+matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
+assert(exist(fullfile(matlab2tikz_dir, 'version-0.3.3'), 'file')==2)
+assert(~isempty(which('matlab2tikz')))
+
+
+%
+% Test Install using MathWorks FileExchange
+%
+
+%% Test download directly from fileexchange
+mpm install covidx -u https://www.mathworks.com/matlabcentral/fileexchange/76213-covidx --force
+covidx_dir = fullfile(mpm_dir, 'mpm-packages', 'covidx');
+assert(exist(fullfile(covidx_dir, 'covidx.m'), 'file')==2)
+assert(~isempty(which('covidx')))
+
+
+%
+% Test Uninstall
+%
+
+%% Test that everything is removed
 mpm install colorbrewer --force
-colorbrewer_dir = fullfile(mpm_dir, 'mpm-packages', 'colorbrewer');
-
-% test that the directory has been created
-% that the file is there and has been added to the path
-assert(exist(colorbrewer_dir, 'dir')==7)
-assert(exist(fullfile(colorbrewer_dir, 'brewermap.m'), 'file')==2)
-assert(~isempty(which('brewermap')))
-
-%% test uninstall
 mpm uninstall colorbrewer --force
-
-% test that everything is removed
+colorbrewer_dir = fullfile(mpm_dir, 'mpm-packages', 'colorbrewer');
 assert(exist(colorbrewer_dir, 'dir')==0)
 assert(exist(fullfile(colorbrewer_dir, 'brewermap.m'), 'file')==0)
 assert(isempty(which('brewermap')))
+
+
+%
+% Test Freeze
+%
+
+%% Test freeze returns 3 installed packages
+results = evalc('mpm freeze');
+assert(contains(results,'export_fig'))
+assert(contains(results,'matlab2tikz==ca56d9f'))
+assert(contains(results,'covidx'))
+
+
+%
+% Test Search
+%
+
+%% Test search returns proper
+results = evalc('mpm search export_fig');
+assert(contains(results,'Found url: https://api.github.com/repos/altmany/export_fig/zipball/v3.'))

--- a/test/test_install.m
+++ b/test/test_install.m
@@ -6,7 +6,7 @@ addpath(mpm_dir)
 
 
 %
-% Test Install using GitHub api (no url)
+% Test Install - using GitHub api (no url)
 %
 
 %% Test install of latest release
@@ -35,7 +35,7 @@ assert(~isempty(which('matlab2tikz')))
 
 
 %
-% Test Install using URL with .git file extension
+% Test Install - using URL with .git file extension
 %
 
 %% Test install of default branch (master)
@@ -64,7 +64,7 @@ assert(~isempty(which('matlab2tikz')))
 
 
 %
-% Test Install using MathWorks FileExchange
+% Test Install - using MathWorks FileExchange
 %
 
 %% Test download directly from fileexchange

--- a/test/test_install.m
+++ b/test/test_install.m
@@ -1,3 +1,6 @@
+% cd test/
+% result = runtests('test_install')
+% table(result)
 clear
 warning('off','backtrace')
 
@@ -5,80 +8,101 @@ mpm_dir = fullfile(pwd, '..');
 addpath(mpm_dir)
 
 
-%
-% Test Install - using GitHub api (no url)
-%
 
-%% Test install of latest release
+% Test API Install - using GitHub api (no url)
+
+%% Test install api latest
 mpm install export_fig --force
 export_fig_dir = fullfile(mpm_dir, 'mpm-packages', 'export_fig');
 assert(exist(fullfile(export_fig_dir, 'export_fig.m'), 'file')==2)
 assert(~isempty(which('export_fig')))
 
-%% Test install of specific tag
+%% Test install api tag
 mpm install matlab2tikz -t 0.4.7 --force
 matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
 assert(exist(fullfile(matlab2tikz_dir, 'version-0.4.7'), 'file')==2)
 assert(~isempty(which('matlab2tikz')))
 
-%% Test install of specific branch
+%% Test install api branch
 mpm install matlab2tikz -t develop --force
 matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
 assert(exist(fullfile(matlab2tikz_dir, 'test/suites/ACID.Octave.4.2.0.md5'), 'file')==2)
 assert(~isempty(which('matlab2tikz')))
 
-%% Test install of specific commit hash
+%% Test install api commit hash
 mpm install matlab2tikz -t ca56d9f --force
 matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
 assert(exist(fullfile(matlab2tikz_dir, 'version-0.3.3'), 'file')==2)
 assert(~isempty(which('matlab2tikz')))
 
 
-%
-% Test Install - using URL with .git file extension
-%
 
-%% Test install of default branch (master)
+% Test URL Install - using URL with .git file extension
+
+%% Test install url default branch
 mpm install matlab2tikz -u https://github.com/matlab2tikz/matlab2tikz.git --force
 matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
 assert(exist(fullfile(matlab2tikz_dir, 'src/matlab2tikz.m'), 'file')==2)
 assert(~isempty(which('matlab2tikz')))
 
-%% Test install of specific tag
+%% Test install url tag
 mpm install matlab2tikz -t 0.4.7 -u https://github.com/matlab2tikz/matlab2tikz.git --force
 matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
 assert(exist(fullfile(matlab2tikz_dir, 'version-0.4.7'), 'file')==2)
 assert(~isempty(which('matlab2tikz')))
 
-%% Test install of specific branch
+%% Test install url branch
 mpm install matlab2tikz -t develop -u https://github.com/matlab2tikz/matlab2tikz.git --force
 matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
 assert(exist(fullfile(matlab2tikz_dir, 'test/suites/ACID.Octave.4.2.0.md5'), 'file')==2)
 assert(~isempty(which('matlab2tikz')))
 
-%% Test install of specific commit hash
+%% Test install url commit hash
 mpm install matlab2tikz -t ca56d9f -u https://github.com/matlab2tikz/matlab2tikz.git --force
 matlab2tikz_dir = fullfile(mpm_dir, 'mpm-packages', 'matlab2tikz');
 assert(exist(fullfile(matlab2tikz_dir, 'version-0.3.3'), 'file')==2)
 assert(~isempty(which('matlab2tikz')))
 
 
-%
-% Test Install - using MathWorks FileExchange
-%
 
-%% Test download directly from fileexchange
+% Test Git Clone Install - using non-GitHub URL with .git file extension
+
+%% Test install git clone default branch
+mpm install hello -u https://bitbucket.org/dhoer/mpm_test.git --force
+mpm_test_dir = fullfile(mpm_dir, 'mpm-packages', 'hello');
+assert(exist(fullfile(mpm_test_dir, 'hello.m'), 'file')==2)
+assert(~isempty(which('hello')))
+
+%% Test install git clone tag
+mpm install hello -t v1.0.0 -u https://bitbucket.org/dhoer/mpm_test.git --force
+mpm_test_dir = fullfile(mpm_dir, 'mpm-packages', 'hello');
+assert(exist(fullfile(mpm_test_dir, 'v1.0.0'), 'file')==2)
+assert(~isempty(which('hello')))
+
+%% Test install git clone branch
+mpm install hello -t develop -u https://bitbucket.org/dhoer/mpm_test.git --force
+mpm_test_dir = fullfile(mpm_dir, 'mpm-packages', 'hello');
+assert(exist(fullfile(mpm_test_dir, 'v2.0.0'), 'file')==2)
+assert(~isempty(which('hello')))
+
+% not working - bitbucket clone of branch using hash not supported
+%%% Test install git clone commit hash
+%mpm install hello -t 36967c34800121b957a2855b8fcf4491dd13866c -u https://bitbucket.org/dhoer/mpm_test.git --force
+%mpm_test_dir = fullfile(mpm_dir, 'mpm-packages', 'hello');
+%assert(exist(fullfile(mpm_test_dir, 'v1.1.0'), 'file')==2)
+%assert(~isempty(which('hello')))
+
+
+
+%% Test install FileExchange
 mpm install covidx -u https://www.mathworks.com/matlabcentral/fileexchange/76213-covidx --force
 covidx_dir = fullfile(mpm_dir, 'mpm-packages', 'covidx');
 assert(exist(fullfile(covidx_dir, 'covidx.m'), 'file')==2)
 assert(~isempty(which('covidx')))
 
 
-%
-% Test Uninstall
-%
 
-%% Test that everything is removed
+%% Test uninstall
 mpm install colorbrewer --force
 mpm uninstall colorbrewer --force
 colorbrewer_dir = fullfile(mpm_dir, 'mpm-packages', 'colorbrewer');
@@ -87,21 +111,24 @@ assert(exist(fullfile(colorbrewer_dir, 'brewermap.m'), 'file')==0)
 assert(isempty(which('brewermap')))
 
 
-%
-% Test Freeze
-%
 
-%% Test freeze returns 3 installed packages
+%% Test freeze
 results = evalc('mpm freeze');
 assert(contains(results,'export_fig'))
 assert(contains(results,'matlab2tikz==ca56d9f'))
 assert(contains(results,'covidx'))
 
 
-%
-% Test Search
-%
 
-%% Test search returns proper
+%% Test search
 results = evalc('mpm search export_fig');
 assert(contains(results,'Found url: https://api.github.com/repos/altmany/export_fig/zipball/v3.'))
+
+
+
+%% Test infile
+cd(mpm_dir)
+mpm install --approve --force -i requirements-example.txt
+assert(~isempty(which('export_fig')))
+assert(~isempty(which('matlab2tikz')))
+assert(~isempty(which('brewermap')))


### PR DESCRIPTION
Fixed the following issues:
- The examples on the readme to install matlab2tikz for tag, commit, and branch don't work. The api download is only for tags. I added a fix for this and as well as tests.
- Readme was missing info about --approve flag.
- Example downloading from fileexchange is not working because download link points to github.  Replaced example with covidx package example that does have download link to fileexchange.  Added test for fileexchange.
- Added tests for search, freeze, install via git clone, and infile
- export_fig  uses git url in requirements-example.txt, since fileexchange doesn't work